### PR TITLE
Rename pkg name to husarion_mecanum_drive_controller

### DIFF
--- a/husarion_mecanum_drive_controller/CHANGELOG.rst
+++ b/husarion_mecanum_drive_controller/CHANGELOG.rst
@@ -1,3 +1,3 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package mecanum_drive_controller
+Changelog for package husarion_mecanum_drive_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/husarion_mecanum_drive_controller/CMakeLists.txt
+++ b/husarion_mecanum_drive_controller/CMakeLists.txt
@@ -2,7 +2,7 @@
 # (https://github.com/ros-controls/ros2_controllers)
 
 cmake_minimum_required(VERSION 3.11)
-project(mecanum_drive_controller)
+project(husarion_mecanum_drive_controller)
 
 # Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
@@ -38,33 +38,37 @@ endforeach()
 get_target_property(TB_INCLUDE_DIRS control_toolbox::rate_limiter_parameters
                     INTERFACE_INCLUDE_DIRECTORIES)
 generate_parameter_library(
-  mecanum_drive_controller_parameters
-  src/mecanum_drive_controller_parameter.yaml
+  husarion_mecanum_drive_controller_parameters
+  src/husarion_mecanum_drive_controller_parameter.yaml
   ${TB_INCLUDE_DIRS}/control_toolbox/custom_validators.hpp)
 
-add_library(mecanum_drive_controller SHARED src/mecanum_drive_controller.cpp
-                                            src/odometry.cpp)
+add_library(husarion_mecanum_drive_controller SHARED
+            src/husarion_mecanum_drive_controller.cpp src/odometry.cpp)
 target_include_directories(
-  mecanum_drive_controller
+  husarion_mecanum_drive_controller
   PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-         $<INSTALL_INTERFACE:include/mecanum_drive_controller>)
+         $<INSTALL_INTERFACE:include/husarion_mecanum_drive_controller>)
 target_link_libraries(
-  mecanum_drive_controller PUBLIC mecanum_drive_controller_parameters
-                                  control_toolbox::rate_limiter_parameters)
-ament_target_dependencies(mecanum_drive_controller PUBLIC
+  husarion_mecanum_drive_controller
+  PUBLIC husarion_mecanum_drive_controller_parameters
+         control_toolbox::rate_limiter_parameters)
+ament_target_dependencies(husarion_mecanum_drive_controller PUBLIC
                           ${THIS_PACKAGE_INCLUDE_DEPENDS})
 pluginlib_export_plugin_description_file(controller_interface
                                          mecanum_drive_plugin.xml)
 
-install(DIRECTORY include/ DESTINATION include/mecanum_drive_controller)
+install(DIRECTORY include/
+        DESTINATION include/husarion_mecanum_drive_controller)
 
 install(
-  TARGETS mecanum_drive_controller mecanum_drive_controller_parameters
-  EXPORT export_mecanum_drive_controller
+  TARGETS husarion_mecanum_drive_controller
+          husarion_mecanum_drive_controller_parameters
+  EXPORT export_husarion_mecanum_drive_controller
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)
 
-ament_export_targets(export_mecanum_drive_controller HAS_LIBRARY_TARGET)
+ament_export_targets(export_husarion_mecanum_drive_controller
+                     HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_package()

--- a/husarion_mecanum_drive_controller/doc/userdoc.rst
+++ b/husarion_mecanum_drive_controller/doc/userdoc.rst
@@ -3,7 +3,7 @@
 .. Copied and adapted from diff_drive_controller (https://github.com/ros-controls/ros2_controllers)
 
 husarion_mecanum_drive_controller
-========================
+=================================
 
 Controller for mobile robots with mecanum drive based on diff_drive_controller (https://github.com/ros-controls/ros2_controllers).
 Input for control are robot body velocity commands which are translated to wheel commands for the mecanum drive base.

--- a/husarion_mecanum_drive_controller/doc/userdoc.rst
+++ b/husarion_mecanum_drive_controller/doc/userdoc.rst
@@ -1,8 +1,8 @@
-.. _mecanum_drive_controller_userdoc:
+.. _husarion_mecanum_drive_controller_userdoc:
 
 .. Copied and adapted from diff_drive_controller (https://github.com/ros-controls/ros2_controllers)
 
-mecanum_drive_controller
+husarion_mecanum_drive_controller
 ========================
 
 Controller for mobile robots with mecanum drive based on diff_drive_controller (https://github.com/ros-controls/ros2_controllers).

--- a/husarion_mecanum_drive_controller/include/husarion_mecanum_drive_controller/husarion_mecanum_drive_controller.hpp
+++ b/husarion_mecanum_drive_controller/include/husarion_mecanum_drive_controller/husarion_mecanum_drive_controller.hpp
@@ -21,8 +21,8 @@
 // Based on: https://ecam-eurobot.github.io/Tutorials/mechanical/mecanum.html
 // Author: Maciej Stępień
 
-#ifndef MECANUM_DRIVE_CONTROLLER__MECANUM_DRIVE_CONTROLLER_HPP_
-#define MECANUM_DRIVE_CONTROLLER__MECANUM_DRIVE_CONTROLLER_HPP_
+#ifndef HUSARION_MECANUM_DRIVE_CONTROLLER__HUSARION_MECANUM_DRIVE_CONTROLLER_HPP_
+#define HUSARION_MECANUM_DRIVE_CONTROLLER__HUSARION_MECANUM_DRIVE_CONTROLLER_HPP_
 
 #include <chrono>
 #include <cmath>
@@ -43,11 +43,11 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
-#include "mecanum_drive_controller/mecanum_drive_controller_parameters.hpp"
-#include "mecanum_drive_controller/odometry.hpp"
-#include "mecanum_drive_controller/speed_limiter.hpp"
+#include "husarion_mecanum_drive_controller/husarion_mecanum_drive_controller_parameters.hpp"
+#include "husarion_mecanum_drive_controller/odometry.hpp"
+#include "husarion_mecanum_drive_controller/speed_limiter.hpp"
 
-namespace mecanum_drive_controller
+namespace husarion_mecanum_drive_controller
 {
 class MecanumDriveController : public controller_interface::ChainableControllerInterface
 {
@@ -156,5 +156,5 @@ protected:
 private:
   void reset_buffers();
 };
-}  // namespace mecanum_drive_controller
-#endif  // MECANUM_DRIVE_CONTROLLER__MECANUM_DRIVE_CONTROLLER_HPP_
+}  // namespace husarion_mecanum_drive_controller
+#endif  // HUSARION_MECANUM_DRIVE_CONTROLLER__HUSARION_MECANUM_DRIVE_CONTROLLER_HPP_

--- a/husarion_mecanum_drive_controller/include/husarion_mecanum_drive_controller/odometry.hpp
+++ b/husarion_mecanum_drive_controller/include/husarion_mecanum_drive_controller/odometry.hpp
@@ -24,13 +24,13 @@
 // Based on: https://ecam-eurobot.github.io/Tutorials/mechanical/mecanum.html
 // Author: Maciej Stępień
 
-#ifndef MECANUM_DRIVE_CONTROLLER__ODOMETRY_HPP_
-#define MECANUM_DRIVE_CONTROLLER__ODOMETRY_HPP_
+#ifndef HUSARION_MECANUM_DRIVE_CONTROLLER__ODOMETRY_HPP_
+#define HUSARION_MECANUM_DRIVE_CONTROLLER__ODOMETRY_HPP_
 
 #include "rclcpp/time.hpp"
 #include "rcpputils/rolling_mean_accumulator.hpp"
 
-namespace mecanum_drive_controller
+namespace husarion_mecanum_drive_controller
 {
 class Odometry
 {
@@ -95,6 +95,6 @@ private:
   RollingMeanAccumulator angular_accumulator_;
 };
 
-}  // namespace mecanum_drive_controller
+}  // namespace husarion_mecanum_drive_controller
 
-#endif  // MECANUM_DRIVE_CONTROLLER__ODOMETRY_HPP_
+#endif  // HUSARION_MECANUM_DRIVE_CONTROLLER__ODOMETRY_HPP_

--- a/husarion_mecanum_drive_controller/include/husarion_mecanum_drive_controller/speed_limiter.hpp
+++ b/husarion_mecanum_drive_controller/include/husarion_mecanum_drive_controller/speed_limiter.hpp
@@ -20,14 +20,14 @@
 // Copied and adapted from diff_drive_controller (https://github.com/ros-controls/ros2_controllers)
 // Author: Maciej Stępień
 
-#ifndef MECANUM_DRIVE_CONTROLLER__SPEED_LIMITER_HPP_
-#define MECANUM_DRIVE_CONTROLLER__SPEED_LIMITER_HPP_
+#ifndef HUSARION_MECANUM_DRIVE_CONTROLLER__SPEED_LIMITER_HPP_
+#define HUSARION_MECANUM_DRIVE_CONTROLLER__SPEED_LIMITER_HPP_
 
 #include <limits>
 
 #include "control_toolbox/rate_limiter.hpp"
 
-namespace mecanum_drive_controller
+namespace husarion_mecanum_drive_controller
 {
 class SpeedLimiter
 {
@@ -146,6 +146,6 @@ private:
   control_toolbox::RateLimiter<double> speed_limiter_;  // Instance of the new RateLimiter
 };
 
-}  // namespace mecanum_drive_controller
+}  // namespace husarion_mecanum_drive_controller
 
-#endif  // MECANUM_DRIVE_CONTROLLER__SPEED_LIMITER_HPP_
+#endif  // HUSARION_MECANUM_DRIVE_CONTROLLER__SPEED_LIMITER_HPP_

--- a/husarion_mecanum_drive_controller/mecanum_drive_plugin.xml
+++ b/husarion_mecanum_drive_controller/mecanum_drive_plugin.xml
@@ -1,6 +1,6 @@
 <!-- Copied and adapted from diff_drive_controller (https://github.com/ros-controls/ros2_controllers) -->
-<library path="mecanum_drive_controller">
-  <class name="mecanum_drive_controller/MecanumDriveController" type="mecanum_drive_controller::MecanumDriveController" base_class_type="controller_interface::ChainableControllerInterface">
+<library path="husarion_mecanum_drive_controller">
+  <class name="husarion_mecanum_drive_controller/MecanumDriveController" type="husarion_mecanum_drive_controller::MecanumDriveController" base_class_type="controller_interface::ChainableControllerInterface">
   <description>
     The mecanum drive controller transforms linear and angular velocity messages into signals for each wheel(s) for a mecanum drive robot.
   </description>

--- a/husarion_mecanum_drive_controller/package.xml
+++ b/husarion_mecanum_drive_controller/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!-- Copied and adapted from diff_drive_controller (https://github.com/ros-controls/ros2_controllers) -->
 <package format="3">
-  <name>mecanum_drive_controller</name>
+  <name>husarion_mecanum_drive_controller</name>
   <version>1.0.0</version>
   <description>Controller for a mecanum drive mobile base.</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>

--- a/husarion_mecanum_drive_controller/src/husarion_mecanum_drive_controller.cpp
+++ b/husarion_mecanum_drive_controller/src/husarion_mecanum_drive_controller.cpp
@@ -21,7 +21,7 @@
 // Based on: https://ecam-eurobot.github.io/Tutorials/mechanical/mecanum.html
 // Author: Maciej Stępień
 
-#include "mecanum_drive_controller/mecanum_drive_controller.hpp"
+#include "husarion_mecanum_drive_controller/husarion_mecanum_drive_controller.hpp"
 
 #include <memory>
 #include <string>
@@ -41,7 +41,7 @@ constexpr auto DEFAULT_ODOMETRY_TOPIC = "~/odom";
 constexpr auto DEFAULT_TRANSFORM_TOPIC = "/tf";
 }  // namespace
 
-namespace mecanum_drive_controller
+namespace husarion_mecanum_drive_controller
 {
 using namespace std::chrono_literals;
 using controller_interface::interface_configuration_type;
@@ -713,10 +713,10 @@ MecanumDriveController::on_export_reference_interfaces()
   return reference_interfaces;
 }
 
-}  // namespace mecanum_drive_controller
+}  // namespace husarion_mecanum_drive_controller
 
 #include "class_loader/register_macro.hpp"
 
 CLASS_LOADER_REGISTER_CLASS(
-  mecanum_drive_controller::MecanumDriveController,
+  husarion_mecanum_drive_controller::MecanumDriveController,
   controller_interface::ChainableControllerInterface)

--- a/husarion_mecanum_drive_controller/src/husarion_mecanum_drive_controller_parameter.yaml
+++ b/husarion_mecanum_drive_controller/src/husarion_mecanum_drive_controller_parameter.yaml
@@ -1,4 +1,4 @@
-mecanum_drive_controller:
+husarion_mecanum_drive_controller:
   front_left_wheel_name: {
     type: string,
     description: "Link name of the front left side wheel",

--- a/husarion_mecanum_drive_controller/src/odometry.cpp
+++ b/husarion_mecanum_drive_controller/src/odometry.cpp
@@ -23,9 +23,9 @@
 
 #include <cmath>
 
-#include "mecanum_drive_controller/odometry.hpp"
+#include "husarion_mecanum_drive_controller/odometry.hpp"
 
-namespace mecanum_drive_controller
+namespace husarion_mecanum_drive_controller
 {
 Odometry::Odometry(size_t velocity_rolling_window_size)
 : timestamp_(0.0),
@@ -190,4 +190,4 @@ void Odometry::resetAccumulators()
   angular_accumulator_ = RollingMeanAccumulator(velocity_rolling_window_size_);
 }
 
-}  // namespace mecanum_drive_controller
+}  // namespace husarion_mecanum_drive_controller


### PR DESCRIPTION
Due to rosdistro conflict it is required to change pkg name. Releated with: https://github.com/ros/rosdistro/pull/50069